### PR TITLE
hack to make sure gcsfs is installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
 - docker pull $DOCKER_IMAGE
 - docker run -d --name pangeo $DOCKER_IMAGE
 - docker exec pangeo bash -c "pip install pytest"
+- docker exec pangeo bash -c "pip install gcsfs"
 - docker ps -a
 
 install:


### PR DESCRIPTION
This would not be necessary if gcsfs were installed in every image. But we need it for now.