### PR TITLE
Upgrade to latest pangeo docker image 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ services:
   - docker
 
 env:
-  - DOCKER_IMAGE=pangeo/pangeo-notebook:2019.04.01 
+  - DOCKER_IMAGE=pangeo/pangeo-notebook:2019.04.19
 
 before_install:
 - docker pull $DOCKER_IMAGE
 - docker run -d --name pangeo $DOCKER_IMAGE
-- docker exec pangeo bash -c "pip install pytest"
 - docker ps -a
+- docker exec pangeo bash -c "pip install pytest"
 
 install:
 - docker cp . pangeo:/home/jovyan/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 
 before_install:
 - docker pull $DOCKER_IMAGE
-- docker run -d --name pangeo $DOCKER_IMAGE
+- docker run -it --name pangeo -p 8888:8888 $DOCKER_IMAGE jupyter notebook --ip 0.0.0.0 --allow-root
 - docker ps -a
 - docker exec pangeo bash -c "pip install pytest"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 
 before_install:
 - docker pull $DOCKER_IMAGE
-- docker run -it --name pangeo -p 8888:8888 $DOCKER_IMAGE jupyter notebook --ip 0.0.0.0 --allow-root
+- docker run -d -it --name pangeo -p 8888:8888 $DOCKER_IMAGE jupyter notebook --ip 0.0.0.0 --allow-root
 - docker ps -a
 - docker exec pangeo bash -c "pip install pytest"
 


### PR DESCRIPTION
This upgrades the CI in this repo to use the latest `pangeo-notebook:2019-04-19` docker image from [pangeo-stacks](https://github.com/pangeo-data/pangeo-stacks/).

When I tested this image locally, it DID NOT WORK. The way I did this matches this repo's .travis.yml
```bash
export DOCKER_IMAGE=pangeo/pangeo-notebook:2019.04.19
docker pull $DOCKER_IMAGE
docker run -d --name pangeo $DOCKER_IMAGE
docker ps -a
```

On my laptop, the docker image dies immediately after the first `docker run` command.

I wonder if this error might have something to do with the big refactor that happened recently in pangeo-stacks.

cc @jhamman, @yuvipanda - do you have any idea why this is happening?