### PR TITLE
update readme [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,12 @@
 
 **Catalog Status**: [![Build Status](https://travis-ci.org/pangeo-data/pangeo-datastore.svg?branch=master)](https://travis-ci.org/pangeo-data/pangeo-datastore) 
 
-----
-
 This repository is where Pangeo's official cloud data catalog lives.
 This catalog is an [Intake](https://github.com/ContinuumIO/intake) catalog.
 Most of the data is stored in [Zarr](https://github.com/zarr-developers/zarr) format
-and meant to be opened with [Xarray](http://xarray.pydata.org/en/latest/)
-
-#.
+and meant to be opened with [Xarray](http://xarray.pydata.org/en/latest/).
 
 The master intake catalog URL is
-
 ```
 https://github.com/pangeo-data/pangeo-datastore/raw/master/intake-catalogs/master.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ and meant to be opened with [Xarray](http://xarray.pydata.org/en/latest/).
 
 The master intake catalog URL is
 ```
-https://github.com/pangeo-data/pangeo-datastore/raw/master/intake-catalogs/master.yaml
+https://raw.githubusercontent.com/pangeo-data/pangeo-datastore/master/intake-catalogs/master.yaml
 ```
 
 ### Requirements
@@ -27,7 +27,7 @@ To open the catalog and load a dataset from python, you can run the following co
 
 ```python
 import intake
-cat_url = 'https://github.com/pangeo-data/pangeo-datastore/raw/master/intake-catalogs/master.yaml'
+cat_url = 'https://raw.githubusercontent.com/pangeo-data/pangeo-datastore/master/intake-catalogs/master.yaml'
 cat = intake.Catalog(cat_url)
 ds = cat.atmosphere.gmet_v1.to_dask()
 ```

--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ cat.walk(depth=5)
 
 ### Adding Datasets
 
-To suggest adding a new dataset, please [open an issue](https://github.com/pangeo-data/pangeo-datastore/issues),
+To suggest adding a new dataset, please [open an issue](https://github.com/pangeo-data/pangeo-datastore/issues).

--- a/README.md
+++ b/README.md
@@ -1,46 +1,47 @@
 # Pangeo Cloud Datastore
 
-[![Build Status](https://travis-ci.org/pangeo-data/pangeo-datastore.svg?branch=master)](https://travis-ci.org/pangeo-data/pangeo-datastore)
+**Catalog Status**: [![Build Status](https://travis-ci.org/pangeo-data/pangeo-datastore.svg?branch=master)](https://travis-ci.org/pangeo-data/pangeo-datastore) 
 
-The Pangeo project has demonstrated the value of placing datasets in cloud
-storage, where they are broadly available and directly accessible to scalable
-cloud computing.
-Xarray, dask, and zarr work very well together in this context.
+----
 
-The next step is to facilitate the creation of cloud-based data repositories.
-Such a repository would have the following elements:
-- A consistent, searchable master database of all the datasets under its control
-- Some sort of ingest mechanism, such as a staging bucket that people can upload
-  to, separate from the production bucket
-- Basic validation of uploaded datasets
-- A web interface to browse the data available
-- A mechanism to assign DOIs
+This repository is where Pangeo's official cloud data catalog lives.
+This catalog is an [Intake](https://github.com/ContinuumIO/intake) catalog.
+Most of the data is stored in [Zarr](https://github.com/zarr-developers/zarr) format
+and meant to be opened with [Xarray](http://xarray.pydata.org/en/latest/)
 
-### Useful Repo Links
+#.
 
-These projects might be useful in developing the datastore.
+The master intake catalog URL is
 
-- **[Zarr](https://github.com/zarr-developers/zarr)**: The storage format
-- **[STAC Spec](https://github.com/radiantearth/stac-spec)**: core STAC specification
-- **[Sat STAC](https://github.com/sat-utils/sat-stac)**: Python library for working with STAC
-- **[Intake](https://github.com/ContinuumIO/intake)**: Python library for loading data
-  (see also [intake-xarray](https://github.com/ContinuumIO/intake-xarray))
-- **[Pydap](https://github.com/pydap/pydap)**: Python-based opendap server
-- **[Opsdroid](https://github.com/opsdroid/opsdroid)**: Chat bot framework written
-  in python aimed at DevOps community.
+```
+https://github.com/pangeo-data/pangeo-datastore/raw/master/intake-catalogs/master.yaml
+```
 
-### Brainstorming User Experience
+### Requirements
 
-I made this flow chart to explain how a datastore service might work.
+Using this catalog requires package versions that are quite recent as of April, 2019.
 
-![schematic diagram](pangeo-stac-schematic.svg)
+- [Intake](https://github.com/ContinuumIO/intake) >= 0.4.4
+- [Xarray](http://xarray.pydata.org/en/latest/) >= 0.12.0
+- [Zarr](https://github.com/zarr-developers/zarr) >= 2.3.1
+- [Dask](https://docs.dask.org/en/latest/) >= 1.0
 
-(Source: [lucidchart](https://www.lucidchart.com/invitations/accept/03c7e060-8db0-4600-a4d9-7160030fb254))
+### Examples
 
-### STAC Examples
+To open the catalog and load a dataset from python, you can run the following code
 
-There are valid example stac files in the `example-stac-entries` folder.
+```python
+import intake
+cat_url = 'https://github.com/pangeo-data/pangeo-datastore/raw/master/intake-catalogs/master.yaml'
+cat = intake.Catalog(cat_url)
+ds = cat.atmosphere.gmet_v1.to_dask()
+```
 
-To upload example files to google cloud
+To explore the whole catalog, you can try
+```python
+cat.walk(depth=5)
+```
 
-    gsutil cp example-stac-entries/*.json gs://pangeo-stac/test/
+### Adding Datasets
+
+To suggest adding a new dataset, please [open an issue](https://github.com/pangeo-data/pangeo-datastore/issues),


### PR DESCRIPTION
The readme has become someout out of sync with the reality of what this repo has become. All of the discussion and links from the previous readme were pasted from various issues, so no info has been lost. The new readme is more focused towards datastore users.