### PR TITLE
add CM2.6 control boundary flux

### DIFF
--- a/intake-catalogs/ocean.yaml
+++ b/intake-catalogs/ocean.yaml
@@ -172,6 +172,20 @@ sources:
         token: anon
       consolidated: True
 
+  GFDL_CM2_6_control_ocean_boundary:
+    description: "GFDL CM2.6 climate model control run ocean boundary flux fields"
+    metadata:
+      url: 'https://www.gfdl.noaa.gov/cm2-6/'
+      tags:
+        - ocean
+        - model
+    driver: zarr
+    args:
+      urlpath: 'gcs://pangeo-data/cm2.6/control/ocean_bdy_flux'
+      storage_options:
+        token: anon
+      consolidated: True
+
   GFDL_CM2_6_control_ocean_3D:
     description: "GFDL CM2.6 climate model control run 5-day-average 3D ocean fields"
     metadata:


### PR DESCRIPTION
This adds the ocean boundary flux fields for CM2.6.

cc @chiara7 