### PR TITLE
Add 2D variables from NG-Aqua CRM data

### DIFF
--- a/intake-catalogs/atmosphere.yaml
+++ b/intake-catalogs/atmosphere.yaml
@@ -51,6 +51,18 @@ sources:
       urlpath: 'gcs://pangeo-data/SAM/NG_5120x2560x34_4km_10s_QOBS_EQX/3d.zarr'
       storage_options:
         token: anon
+       
+  sam_ngaqua_qobs_eqx_2d:
+    description: @D fields from a near-global Aquaplanet Simulation with the System for Atmospheric Modeling
+    metadata:
+      tags:
+        - atmosphere
+        - model
+    driver: zarr
+    args:
+      urlpath: 'gcs://pangeo-data/SAM/NG_5120x2560x34_4km_10s_QOBS_EQX/2d.zarr'
+      storage_options:
+        token: anon
 
   gpcp_cdr_daily_v1_3:
     description: 3D fields from a near-global Aquaplanet Simulation with the System for Atmospheric Modeling

--- a/intake-catalogs/atmosphere.yaml
+++ b/intake-catalogs/atmosphere.yaml
@@ -53,7 +53,7 @@ sources:
         token: anon
        
   sam_ngaqua_qobs_eqx_2d:
-    description: @D fields from a near-global Aquaplanet Simulation with the System for Atmospheric Modeling
+    description: 2D fields from a near-global Aquaplanet Simulation with the System for Atmospheric Modeling
     metadata:
       tags:
         - atmosphere


### PR DESCRIPTION
The three dimensional fields (e.g. winds, humidity, and temperature) for this simulation were already in the catalog with the key  `sam_ngaqua_qobs_eqx_3d`. This commit also adds a catalog entry for two-dimensional variables (e.g. precipitation, top of atmosphere radiation), which I finally got around to uploading. 

I plotted the zonal+time mean of the data from hub.pangeo.io as a sanity check.