### PR TITLE
Add cmip6 CSV catalog

### DIFF
--- a/docs/cmip6_catalog.rst
+++ b/docs/cmip6_catalog.rst
@@ -1,5 +1,5 @@
-CMIP6 Catalog
-=============
+CMIP6 CSV Catalog
+=================
 
 .. raw:: html
 

--- a/docs/cmip6_catalog.rst
+++ b/docs/cmip6_catalog.rst
@@ -4,29 +4,6 @@ CMIP6 Catalog
 .. raw:: html
 
   <head>
-    <style>
-      html,
-      body {
-        height: 100%;
-        width: 100%;
-        margin: 0;
-        box-sizing: border-box;
-        -webkit-overflow-scrolling: touch;
-      }
-
-      html {
-        position: absolute;
-        top: 0;
-        left: 0;
-        padding: 0;
-        overflow: auto;
-      }
-
-      body {
-        padding: 1rem;
-        overflow: auto;
-      }
-    </style>
     <script src="https://unpkg.com/papaparse@5.1.0/papaparse.min.js"></script>
     <script src="https://unpkg.com/ag-grid-community/dist/ag-grid-community.min.noStyle.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/ag-grid-community/dist/styles/ag-grid.css">
@@ -58,8 +35,15 @@ CMIP6 Catalog
 
         // let the grid know which columns and what data to use
         var gridOptions = {
+          defaultColDef: {
+            editable: true,
+            sortable: true,
+            filter: true
+          },
           columnDefs: columnDefs,
           rowData: results.data,
+          rowSelection: 'multiple',
+          enableCellTextSelection: true,
           onGridReady: function(params) {
             params.api.sizeColumnsToFit();
 
@@ -86,9 +70,7 @@ CMIP6 Catalog
         for (var i = 0; i < fields.length; i++) {
           columnDefs.push({
             headerName: fields[i],
-            field: fields[i],
-            sortable: true,
-            filter: true
+            field: fields[i]
           });
         }
 

--- a/docs/cmip6_catalog.rst
+++ b/docs/cmip6_catalog.rst
@@ -1,0 +1,65 @@
+CMIP6 Catalog
+=============
+
+.. raw:: html
+
+  <head>
+    <script src="https://unpkg.com/papaparse@5.1.0/papaparse.min.js"></script>
+    <script src="https://unpkg.com/ag-grid-community/dist/ag-grid-community.min.noStyle.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/ag-grid-community/dist/styles/ag-grid.css">
+    <link rel="stylesheet" href="https://unpkg.com/ag-grid-community/dist/styles/ag-theme-balham.css">
+  </head>
+
+  <body>
+    <div id="myGrid" style="height: 600px;width:1000px;" class="ag-theme-balham"></div>
+
+    <script type="text/javascript" charset="utf-8">
+      // load in sample CSV catalog
+      Papa.parse("https://storage.googleapis.com/pangeo-cmip6/pangeo-cmip6-zarr-consolidated-stores.csv", {
+        download: true,
+        header: true,
+        complete: function(results) {
+          makeGrid(results);
+        }
+      });
+
+      // Main function to produce ag-Grid based on CSV table
+      function makeGrid(results) {
+
+        // specify the columms
+        var columnDefs = getColumnDefs(results.meta.fields);
+
+        // let the grid know which columns and what data to use
+        var gridOptions = {
+          columnDefs: columnDefs,
+          rowData: results.data,
+          onFirstDataRendered(params) {
+            params.api.sizeColumnsToFit();
+          }
+        };
+
+        // lookup the container we want the Grid to use
+        var eGridDiv = document.querySelector('#myGrid');
+
+        // create the grid passing in the div to use together with the columns & data we want to use
+        new agGrid.Grid(eGridDiv, gridOptions);
+      }
+
+      // Get column definitions based on parsed fields
+      function getColumnDefs(fields) {
+
+        var columnDefs = [];
+
+        for (var i = 0; i < fields.length; i++) {
+          columnDefs.push({
+            headerName: fields[i],
+            field: fields[i],
+            sortable: true,
+            filter: true
+          });
+        }
+
+        return columnDefs;
+      }
+    </script>
+  </body>

--- a/docs/cmip6_catalog.rst
+++ b/docs/cmip6_catalog.rst
@@ -3,78 +3,69 @@ CMIP6 CSV Catalog
 
 .. raw:: html
 
-  <head>
-    <script src="https://unpkg.com/papaparse@5.1.0/papaparse.min.js"></script>
-    <script src="https://unpkg.com/ag-grid-community/dist/ag-grid-community.min.noStyle.js"></script>
-    <link rel="stylesheet" href="https://unpkg.com/ag-grid-community/dist/styles/ag-grid.css">
-    <link rel="stylesheet" href="https://unpkg.com/ag-grid-community/dist/styles/ag-theme-balham.css">
-  </head>
-
-  <body>
-    <div style="display: flex; flex-direction: row">
-      <div style="overflow: auto; flex-grow: 1">
-        <div id="myGrid" class="ag-theme-balham" style="height: 600px; width: 100%;"></div>
-      </div>
+  <div style="display: flex; flex-direction: row">
+    <div style="overflow: auto; flex-grow: 1">
+      <div id="myGrid" class="ag-theme-balham" style="height: 600px; width: 100%;"></div>
     </div>
+  </div>
 
-    <script type="text/javascript" charset="utf-8">
-      // load in sample CSV catalog
-      Papa.parse("https://storage.googleapis.com/pangeo-cmip6/pangeo-cmip6-zarr-consolidated-stores.csv", {
-        download: true,
-        header: true,
-        complete: function(results) {
-          makeGrid(results);
-        }
-      });
+  <script type="text/javascript" charset="utf-8">
+    // load in sample CSV catalog
+    Papa.parse("https://storage.googleapis.com/pangeo-cmip6/pangeo-cmip6-zarr-consolidated-stores.csv", {
+      download: true,
+      header: true,
+      complete: function(results) {
+        makeGrid(results);
+      }
+    });
 
-      // Main function to produce ag-Grid based on CSV table
-      function makeGrid(results) {
+    // Main function to produce ag-Grid based on CSV table
+    function makeGrid(results) {
 
-        // specify the columms
-        var columnDefs = getColumnDefs(results.meta.fields);
+      // specify the columms
+      var columnDefs = getColumnDefs(results.meta.fields);
 
-        // let the grid know which columns and what data to use
-        var gridOptions = {
-          defaultColDef: {
-            editable: true,
-            sortable: true,
-            filter: true
-          },
-          columnDefs: columnDefs,
-          rowData: results.data,
-          rowSelection: 'multiple',
-          enableCellTextSelection: true,
-          onGridReady: function(params) {
-            params.api.sizeColumnsToFit();
+      // let the grid know which columns and what data to use
+      var gridOptions = {
+        defaultColDef: {
+          editable: true,
+          sortable: true,
+          filter: true
+        },
+        columnDefs: columnDefs,
+        rowData: results.data,
+        rowSelection: 'multiple',
+        enableCellTextSelection: true,
+        onGridReady: function(params) {
+          params.api.sizeColumnsToFit();
 
-            window.addEventListener('resize', function() {
-              setTimeout(function() {
-                params.api.sizeColumnsToFit();
-              })
+          window.addEventListener('resize', function() {
+            setTimeout(function() {
+              params.api.sizeColumnsToFit();
             })
-          }
-        };
-
-        // lookup the container we want the Grid to use
-        var eGridDiv = document.querySelector('#myGrid');
-
-        // create the grid passing in the div to use together with the columns & data we want to use
-        new agGrid.Grid(eGridDiv, gridOptions);
-      }
-
-      // Get column definitions based on parsed fields
-      function getColumnDefs(fields) {
-
-        var columnDefs = [];
-
-        for (var i = 0; i < fields.length; i++) {
-          columnDefs.push({
-            headerName: fields[i],
-            field: fields[i]
-          });
+          })
         }
+      };
 
-        return columnDefs;
+      // lookup the container we want the Grid to use
+      var eGridDiv = document.querySelector('#myGrid');
+
+      // create the grid passing in the div to use together with the columns & data we want to use
+      new agGrid.Grid(eGridDiv, gridOptions);
+    }
+
+    // Get column definitions based on parsed fields
+    function getColumnDefs(fields) {
+
+      var columnDefs = [];
+
+      for (var i = 0; i < fields.length; i++) {
+        columnDefs.push({
+          headerName: fields[i],
+          field: fields[i]
+        });
       }
-    </script>
-  </body>
+
+      return columnDefs;
+    }
+  </script>

--- a/docs/cmip6_catalog.rst
+++ b/docs/cmip6_catalog.rst
@@ -4,6 +4,29 @@ CMIP6 Catalog
 .. raw:: html
 
   <head>
+    <style>
+      html,
+      body {
+        height: 100%;
+        width: 100%;
+        margin: 0;
+        box-sizing: border-box;
+        -webkit-overflow-scrolling: touch;
+      }
+
+      html {
+        position: absolute;
+        top: 0;
+        left: 0;
+        padding: 0;
+        overflow: auto;
+      }
+
+      body {
+        padding: 1rem;
+        overflow: auto;
+      }
+    </style>
     <script src="https://unpkg.com/papaparse@5.1.0/papaparse.min.js"></script>
     <script src="https://unpkg.com/ag-grid-community/dist/ag-grid-community.min.noStyle.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/ag-grid-community/dist/styles/ag-grid.css">
@@ -11,7 +34,11 @@ CMIP6 Catalog
   </head>
 
   <body>
-    <div id="myGrid" style="height: 600px;width:1000px;" class="ag-theme-balham"></div>
+    <div style="display: flex; flex-direction: row">
+      <div style="overflow: auto; flex-grow: 1">
+        <div id="myGrid" class="ag-theme-balham" style="height: 600px; width: 100%;"></div>
+      </div>
+    </div>
 
     <script type="text/javascript" charset="utf-8">
       // load in sample CSV catalog
@@ -33,8 +60,14 @@ CMIP6 Catalog
         var gridOptions = {
           columnDefs: columnDefs,
           rowData: results.data,
-          onFirstDataRendered(params) {
+          onGridReady: function(params) {
             params.api.sizeColumnsToFit();
+
+            window.addEventListener('resize', function() {
+              setTimeout(function() {
+                params.api.sizeColumnsToFit();
+              })
+            })
           }
         };
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -183,4 +183,8 @@ def rstjinja(app, docname, source):
 def setup(app):
     app.add_stylesheet("https://netdna.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css")
     app.add_stylesheet("catalog-custom.css")
+    app.add_stylesheet("https://unpkg.com/ag-grid-community/dist/styles/ag-grid.css")
+    app.add_stylesheet("https://unpkg.com/ag-grid-community/dist/styles/ag-theme-balham.css")
+    app.add_javascript("https://unpkg.com/papaparse@5.1.0/papaparse.min.js")
+    app.add_javascript("https://unpkg.com/ag-grid-community/dist/ag-grid-community.min.noStyle.js")
     app.connect("source-read", rstjinja)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,18 +21,14 @@ The master intake catalog URL is::
 Examples
 --------
 
-To open the catalog and load a dataset from python, you can run the following code:
-
-.. code:: python
+To open the catalog and load a dataset from python, you can run the following code::
 
     import intake
     cat_url = 'https://raw.githubusercontent.com/pangeo-data/pangeo-datastore/master/intake-catalogs/master.yaml'
     cat = intake.Catalog(cat_url)
     ds = cat.atmosphere.gmet_v1.to_dask()
 
-To explore the whole catalog, you can try:
-
-.. code:: python
+To explore the whole catalog, you can try::
 
     cat.walk(depth=5)
 
@@ -44,7 +40,6 @@ This website is a statically generated Sphinx site from which you can browse the
 .. toctree::
    :maxdepth: 3
 
-   cmip6_catalog
    master
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,7 @@ This website is a statically generated Sphinx site from which you can browse the
 .. toctree::
    :maxdepth: 3
 
+   cmip6_catalog
    master
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,14 +21,18 @@ The master intake catalog URL is::
 Examples
 --------
 
-To open the catalog and load a dataset from python, you can run the following code::
+To open the catalog and load a dataset from python, you can run the following code:
+
+.. code:: python
 
     import intake
     cat_url = 'https://raw.githubusercontent.com/pangeo-data/pangeo-datastore/master/intake-catalogs/master.yaml'
     cat = intake.Catalog(cat_url)
     ds = cat.atmosphere.gmet_v1.to_dask()
 
-To explore the whole catalog, you can try::
+To explore the whole catalog, you can try:
+
+.. code:: python
 
     cat.walk(depth=5)
 
@@ -40,6 +44,7 @@ This website is a statically generated Sphinx site from which you can browse the
 .. toctree::
    :maxdepth: 3
 
+   cmip6_catalog
    master
 
 


### PR DESCRIPTION
This adds an entry for the CMIP6 CSV catalog to the top level of Pangeo's data catalog; this allows users to browse the CSV file with all zarr store paths in a spreadsheet format, complete with the same sorting/filtering used by qgrid.