### PR TITLE
Added new catalog for GLADE

### DIFF
--- a/docs/cmip6_glade.rst
+++ b/docs/cmip6_glade.rst
@@ -1,0 +1,71 @@
+CMIP6 GLADE Catalog
+===================
+
+.. raw:: html
+
+  <div style="display: flex; flex-direction: row">
+    <div style="overflow: auto; flex-grow: 1">
+      <div id="myGrid" class="ag-theme-balham" style="height: 600px; width: 100%;"></div>
+    </div>
+  </div>
+
+  <script type="text/javascript" charset="utf-8">
+    // load in sample CSV catalog
+    Papa.parse("https://storage.googleapis.com/pangeo-cmip6/glade-cmip6.csv.gz", {
+      download: true,
+      header: true,
+      complete: function(results) {
+        makeGrid(results);
+      }
+    });
+
+    // Main function to produce ag-Grid based on CSV table
+    function makeGrid(results) {
+
+      // specify the columms
+      var columnDefs = getColumnDefs(results.meta.fields);
+
+      // let the grid know which columns and what data to use
+      var gridOptions = {
+        defaultColDef: {
+          editable: true,
+          sortable: true,
+          filter: true
+        },
+        columnDefs: columnDefs,
+        rowData: results.data,
+        rowSelection: 'multiple',
+        enableCellTextSelection: true,
+        onGridReady: function(params) {
+          params.api.sizeColumnsToFit();
+
+          window.addEventListener('resize', function() {
+            setTimeout(function() {
+              params.api.sizeColumnsToFit();
+            })
+          })
+        }
+      };
+
+      // lookup the container we want the Grid to use
+      var eGridDiv = document.querySelector('#myGrid');
+
+      // create the grid passing in the div to use together with the columns & data we want to use
+      new agGrid.Grid(eGridDiv, gridOptions);
+    }
+
+    // Get column definitions based on parsed fields
+    function getColumnDefs(fields) {
+
+      var columnDefs = [];
+
+      for (var i = 0; i < fields.length; i++) {
+        columnDefs.push({
+          headerName: fields[i],
+          field: fields[i]
+        });
+      }
+
+      return columnDefs;
+    }
+  </script>

--- a/docs/cmip6_pangeo.rst
+++ b/docs/cmip6_pangeo.rst
@@ -1,0 +1,71 @@
+CMIP6 Pangeo Catalog
+====================
+
+.. raw:: html
+
+  <div style="display: flex; flex-direction: row">
+    <div style="overflow: auto; flex-grow: 1">
+      <div id="myGrid" class="ag-theme-balham" style="height: 600px; width: 100%;"></div>
+    </div>
+  </div>
+
+  <script type="text/javascript" charset="utf-8">
+    // load in sample CSV catalog
+    Papa.parse("https://storage.googleapis.com/pangeo-cmip6/pangeo-cmip6-zarr-consolidated-stores.csv", {
+      download: true,
+      header: true,
+      complete: function(results) {
+        makeGrid(results);
+      }
+    });
+
+    // Main function to produce ag-Grid based on CSV table
+    function makeGrid(results) {
+
+      // specify the columms
+      var columnDefs = getColumnDefs(results.meta.fields);
+
+      // let the grid know which columns and what data to use
+      var gridOptions = {
+        defaultColDef: {
+          editable: true,
+          sortable: true,
+          filter: true
+        },
+        columnDefs: columnDefs,
+        rowData: results.data,
+        rowSelection: 'multiple',
+        enableCellTextSelection: true,
+        onGridReady: function(params) {
+          params.api.sizeColumnsToFit();
+
+          window.addEventListener('resize', function() {
+            setTimeout(function() {
+              params.api.sizeColumnsToFit();
+            })
+          })
+        }
+      };
+
+      // lookup the container we want the Grid to use
+      var eGridDiv = document.querySelector('#myGrid');
+
+      // create the grid passing in the div to use together with the columns & data we want to use
+      new agGrid.Grid(eGridDiv, gridOptions);
+    }
+
+    // Get column definitions based on parsed fields
+    function getColumnDefs(fields) {
+
+      var columnDefs = [];
+
+      for (var i = 0; i < fields.length; i++) {
+        columnDefs.push({
+          headerName: fields[i],
+          field: fields[i]
+        });
+      }
+
+      return columnDefs;
+    }
+  </script>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -186,5 +186,5 @@ def setup(app):
     app.add_stylesheet("https://unpkg.com/ag-grid-community/dist/styles/ag-grid.css")
     app.add_stylesheet("https://unpkg.com/ag-grid-community/dist/styles/ag-theme-balham.css")
     app.add_javascript("https://unpkg.com/papaparse@5.1.0/papaparse.min.js")
-    app.add_javascript("https://unpkg.com/ag-grid-community/dist/ag-grid-community.min.noStyle.js")
+    app.add_javascript("https://unpkg.com/ag-grid-enterprise@21.2.1/dist/ag-grid-enterprise.min.js")
     app.connect("source-read", rstjinja)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,8 +40,9 @@ This website is a statically generated Sphinx site from which you can browse the
 .. toctree::
    :maxdepth: 3
 
-   cmip6_catalog
    master
+   cmip6_pangeo
+   cmip6_glade
 
 
 .. _Intake: https://intake.readthedocs.io


### PR DESCRIPTION
This adds a new page to the top directory of the Pangeo Datastore that gives a browser view of the GLADE catalog; next step is to consolidate these two pages under one parent page (which ideally provides some information about their purpose with regards to the hackathon), and then to parse through the associated JSON metadata for each catalog. 