### PR TITLE
add CMIP6 and LENS catalogs

### DIFF
--- a/intake-catalogs/climate.yaml
+++ b/intake-catalogs/climate.yaml
@@ -1,0 +1,20 @@
+plugins:
+  source:
+    - module: intake_xarray
+    - module: intake_esm
+
+sources:
+
+  cmip6_gcs:
+    args:
+      esmcol_path: "https://raw.githubusercontent.com/NCAR/intake-esm-datastore/master/catalogs/pangeo-cmip6.json"
+    description: 'CMIP6 in Google Cloud Storage'
+    driver: intake_esm.esm_datastore
+    metadata: {}
+
+  cmip6_s3:
+    args:
+      esmcol_path: "https://github.com/NCAR/cesm-lens-aws/blob/master/intake-catalogs/aws-cesm1-le.json"
+    description: 'NCAR Large Ensemble in AWS S3 Storage'
+    driver: intake_esm.esm_datastore
+    metadata: {}

--- a/intake-catalogs/master.yaml
+++ b/intake-catalogs/master.yaml
@@ -15,6 +15,13 @@ sources:
     driver: intake.catalog.local.YAMLFileCatalog
     metadata: {}
 
+  climate:
+    args:
+      path: "{{CATALOG_DIR}}/climate.yaml"
+    description: 'Pangeo Climate Dataset Catalog. Include model ensembles such as CMIP6 and LENS.'
+    driver: intake.catalog.local.YAMLFileCatalog
+    metadata: {}
+
   hydro:
     args:
       path: "{{CATALOG_DIR}}/hydro.yaml"


### PR DESCRIPTION
We figured out how to embed ESM collection datasets in an existing intake catalog. Thanks for @jhamman for the help.

To load the collection:
```python
import intake
cat = intake.open_catalog('intake-catalogs/master.yaml')
esm_dstore = cat.climate.cmip6_gcs()
```

cc @andersy005 