### PR TITLE
Update CESM Large Ensemble identifier

### DIFF
--- a/intake-catalogs/climate.yaml
+++ b/intake-catalogs/climate.yaml
@@ -12,7 +12,7 @@ sources:
     driver: intake_esm.esm_datastore
     metadata: {}
 
-  cmip6_s3:
+  cesm1_lens_s3:
     args:
       esmcol_path: "https://raw.githubusercontent.com/NCAR/cesm-lens-aws/master/intake-catalogs/aws-cesm1-le.json"
     description: 'NCAR Large Ensemble in AWS S3 Storage'


### PR DESCRIPTION
In response to https://github.com/pangeo-data/pangeo-datastore/pull/75#discussion_r370192196, I asked around to see if there's any "official" identifier for CESM Large Ensemble dataset. It turns out that there isn't any (as far I can tell from the two responses I got). 