### PR TITLE
Fix indent issue with ocean budgets

### DIFF
--- a/intake-catalogs/ocean/GFDL_CM2.6.yaml
+++ b/intake-catalogs/ocean/GFDL_CM2.6.yaml
@@ -158,7 +158,7 @@ sources:
       storage_options:
         requester_pays: True
 
-GFDL_CM2_6_one_percent_ocean_budgets:
+  GFDL_CM2_6_one_percent_ocean_budgets:
     description: "GFDL CM2.6 climate model one-percent CO2 increase monthly ocean budgets fields"
     metadata:
       url: 'https://www.gfdl.noaa.gov/cm2-6/'


### PR DESCRIPTION
This should fix problems on the dynamic site and elsewhere - looks like the ocean budgets entry just needed an indent fix.