### PR TITLE
Adding era5 hourly reanalysis (single levels) to atmosphere catalog

### DIFF
--- a/intake-catalogs/atmosphere.yaml
+++ b/intake-catalogs/atmosphere.yaml
@@ -71,3 +71,18 @@ sources:
       consolidated: True
       storage_options:
         requester_pays: True
+
+  era5_hourly_reanalysis_single_levels_sa:
+    description: "ERA5 hourly estimates of variables on single levels"
+    metadata:
+      url: 'https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-single-levels'
+      tags:
+      - ocean
+      - model
+      - atmosphere
+    driver: zarr
+    args:
+      urlpath: gs://pangeo-era5/reanalysis/spatial-analysis
+      consolidated: True
+      storage_options:
+        requester_pays: True


### PR DESCRIPTION
Adding era5 hourly reanalysis (single levels) to pangeo athmophere catalog as _era5_hourly_reanalysis_single_levels_sa_. 

**sa** stands for spatial analysis to reflect how zarr chunks were optimized for spatial analysis rather than temporal analysis. This was added because there were conversations about eventually creating an era5 datasets chunked optimally for temporal analysis.