### PR TITLE
Add entry for CM2.6 esm collection

### DIFF
--- a/intake-catalogs/climate.yaml
+++ b/intake-catalogs/climate.yaml
@@ -11,6 +11,13 @@ sources:
     description: 'CMIP6 in Google Cloud Storage'
     driver: intake_esm.esm_datastore
     metadata: {}
+   
+  GFDL_CM2_6:
+    args:
+      esmcol_path: "https://storage.googleapis.com/cmip6/gfdl_cm2_6.json"
+    description: "NOAA-GFDL CM2.6 in Google Cloud Storage"
+    driver: intake_esm.esm_datastore
+    metadata: {}
     
   tracmip:
     args:
@@ -18,4 +25,3 @@ sources:
     description: "TRACMIP in Pangeo Google Cloud Storage"
     driver: intake_esm.esm_datastore
     metadata: {}
-


### PR DESCRIPTION
This adds a CM2.6 ESM collection to our climate catalog, with the collections specs themselves residing in Google's CMIP6 bucket.