### PR TITLE
Update locations of CM2.6 data

### DIFF
--- a/intake-catalogs/ocean/GFDL_CM2.6.yaml
+++ b/intake-catalogs/ocean/GFDL_CM2.6.yaml
@@ -13,7 +13,7 @@ sources:
         - model
     driver: zarr
     args:
-      urlpath: gs://pangeo-gfdl-cm26/control/ocean
+      urlpath: gs://cmip6/GFDL_CM2_6/control/ocean
       consolidated: True
       storage_options:
         requester_pays: True
@@ -27,7 +27,7 @@ sources:
         - model
     driver: zarr
     args:
-      urlpath: gs://pangeo-gfdl-cm26/control/surface
+      urlpath: gs://cmip6/GFDL_CM2_6/control/surface
       consolidated: True
       storage_options:
         requester_pays: True
@@ -41,7 +41,7 @@ sources:
         - model
     driver: zarr
     args:
-      urlpath: gs://pangeo-gfdl-cm26/control/ocean_3d
+      urlpath: gs://cmip6/GFDL_CM2_6/control/ocean_3d
       consolidated: True
       storage_options:
         requester_pays: True
@@ -55,7 +55,7 @@ sources:
         - model
     driver: zarr
     args:
-      urlpath: gs://pangeo-gfdl-cm26/control/ocean_transport
+      urlpath: gs://cmip6/GFDL_CM2_6/control/ocean_transport
       consolidated: True
       storage_options:
         requester_pays: True
@@ -69,7 +69,7 @@ sources:
         - model
     driver: zarr
     args:
-      urlpath: gs://pangeo-gfdl-cm26/control/ocean_boundary
+      urlpath: gs://cmip6/GFDL_CM2_6/control/ocean_boundary
       consolidated: True
       storage_options:
         requester_pays: True
@@ -83,7 +83,7 @@ sources:
         - model
     driver: zarr
     args:
-      urlpath: gs://pangeo-gfdl-cm26/control/ocean_budgets
+      urlpath: gs://cmip6/GFDL_CM2_6/control/ocean_budgets
       consolidated: True
       storage_options:
         requester_pays: True
@@ -97,7 +97,7 @@ sources:
         - model
     driver: zarr
     args:
-      urlpath: gs://pangeo-gfdl-cm26/one_percent/ocean
+      urlpath: gs://cmip6/GFDL_CM2_6/one_percent/ocean
       consolidated: True
       storage_options:
         requester_pays: True
@@ -111,7 +111,7 @@ sources:
         - model
     driver: zarr
     args:
-      urlpath: gs://pangeo-gfdl-cm26/one_percent/surface
+      urlpath: gs://cmip6/GFDL_CM2_6/one_percent/surface
       consolidated: True
       storage_options:
         requester_pays: True
@@ -125,7 +125,7 @@ sources:
         - model
     driver: zarr
     args:
-      urlpath: gs://pangeo-gfdl-cm26/one_percent/ocean_3d
+      urlpath: gs://cmip6/GFDL_CM2_6/one_percent/ocean_3d
       consolidated: True
       storage_options:
         requester_pays: True
@@ -139,7 +139,7 @@ sources:
         - model
     driver: zarr
     args:
-      urlpath: gs://pangeo-gfdl-cm26/one_percent/ocean_transport
+      urlpath: gs://cmip6/GFDL_CM2_6/one_percent/ocean_transport
       consolidated: True
       storage_options:
         requester_pays: True
@@ -153,7 +153,7 @@ sources:
         - model
     driver: zarr
     args:
-      urlpath: gs://pangeo-gfdl-cm26/one_percent/ocean_boundary
+      urlpath: gs://cmip6/GFDL_CM2_6/one_percent/ocean_boundary
       consolidated: True
       storage_options:
         requester_pays: True
@@ -167,7 +167,7 @@ sources:
         - model
     driver: zarr
     args:
-      urlpath: gs://pangeo-gfdl-cm26/one_percent/ocean_budgets
+      urlpath: gs://cmip6/GFDL_CM2_6/one_percent/ocean_budgets
       consolidated: True
       storage_options:
         requester_pays: True
@@ -181,7 +181,7 @@ sources:
         - model
     driver: zarr
     args:
-      urlpath: gs://pangeo-gfdl-cm26/grid
+      urlpath: gs://cmip6/GFDL_CM2_6/grid
       consolidated: True
       storage_options:
         requester_pays: True


### PR DESCRIPTION
This updates the catalogs to point to a copy of GFDL's CM2.6 in Google's own CMIP6 bucket. If all goes well and the data is accessible there, the next step would be to remove this data from `gs://pangeo-gfdl-cm26`.