### PR TITLE
Add skipped case for parquet datasets

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -29,3 +29,5 @@ def test_get_intake_source(catalog, dataset_name):
         elif item._driver == "intake_esm.esm_datastore":
             pytest.skip("need to resolve credentials issue for requester-pays data")
             # col = item.get()
+        elif item._driver == "parquet":
+            pytest.skip("need to add intake-parquet plugin to handle parquet datasets")

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -19,15 +19,18 @@ def dataset_name(request):
     return request.param
 
 def test_get_intake_source(catalog, dataset_name):
-    item = catalog[dataset_name]
-    if item.container == "catalog":
-        item.reload()   
-    else:
-        if item._driver in ["csv", "rasterio", "zarr"]:
-            pytest.skip("need to resolve credentials issue for requester-pays data")
-            # ds = item.to_dask()
-        elif item._driver == "intake_esm.esm_datastore":
-            pytest.skip("need to resolve credentials issue for requester-pays data")
-            # col = item.get()
-        elif item._driver == "parquet":
-            pytest.skip("need to add intake-parquet plugin to handle parquet datasets")
+    try:
+        item = catalog[dataset_name]
+        if item.container == "catalog":
+            item.reload()   
+        else:
+            if item._driver in ["csv", "rasterio", "zarr"]:
+                pytest.skip("need to resolve credentials issue for requester-pays data")
+                # ds = item.to_dask()
+            elif item._driver == "intake_esm.esm_datastore":
+                pytest.skip("need to resolve credentials issue for requester-pays data")
+                # col = item.get()
+            elif item._driver == "parquet":
+                pytest.skip("need to add intake-parquet plugin to handle parquet datasets")
+    except KeyError:
+        pytest.skip("single file ESM collections need to be addressed with a Docker container bump")


### PR DESCRIPTION
This will add a conditional to skip over parquet-based datasets for the time being, as the Docker image for pangeo-datastore does not have intake-parquet as a package. 

This is part of a larger issue with eventually fixing the CI of this repo to be able to access datasets in requester pays buckets, but this should at least allow for #86 to go through.