### PR TITLE
Remove anon token option from soil_grids

### DIFF
--- a/intake-catalogs/hydro.yaml
+++ b/intake-catalogs/hydro.yaml
@@ -81,7 +81,6 @@ sources:
     args:
       urlpath: "gs://pangeo-data/soilgrids/{{ variable }}_250m.tif"
       chunks: {'y': 5120, 'x': 5120}
-      storage_options: {'anon': True}  # TODO: remove, see GH#61
 
   soil_grids_multi_level:
     description: Global gridded soil information in COG format
@@ -101,7 +100,6 @@ sources:
     args:
       urlpath: "gs://pangeo-data/soilgrids/{{ variable }}_sl{{ '%01d' % level }}_250m.tif"
       chunks: {'y': 5120, 'x': 5120}
-      storage_options: {'anon': True}  # TODO: remove, see GH#61
 
   camels:
     args:


### PR DESCRIPTION
This should finish up the work of #61; noticed some issues when trying to open these datasets through the catalog site that may be a result of the anonymous credentials being used to access this data.