### PR TITLE
Relocating NCAR Camels / SoilGrids

### DIFF
--- a/intake-catalogs/hydro.yaml
+++ b/intake-catalogs/hydro.yaml
@@ -79,7 +79,7 @@ sources:
       tags: Soil
     driver: rasterio
     args:
-      urlpath: "gs://pangeo-data/soilgrids/{{ variable }}_250m.tif"
+      urlpath: "gs://pangeo-ncar-soilgrids/{{ variable }}_250m.tif"
       chunks: {'y': 5120, 'x': 5120}
 
   soil_grids_multi_level:
@@ -98,7 +98,7 @@ sources:
       tags: Soil
     driver: rasterio
     args:
-      urlpath: "gs://pangeo-data/soilgrids/{{ variable }}_sl{{ '%01d' % level }}_250m.tif"
+      urlpath: "gs://pangeo-ncar-soilgrids/{{ variable }}_sl{{ '%01d' % level }}_250m.tif"
       chunks: {'y': 5120, 'x': 5120}
 
   camels:

--- a/intake-catalogs/hydro/camels.yaml
+++ b/intake-catalogs/hydro/camels.yaml
@@ -12,7 +12,7 @@ sources:
         default: daymet
     driver: csv
     args:
-      urlpath: 'gs://pangeo-data/camels/basin_dataset_public_v1p2/basin_mean_forcing/{{ source }}/*/{{ basin_id }}_*.txt'
+      urlpath: 'gs://pangeo-ncar-camels/basin_dataset_public_v1p2/basin_mean_forcing/{{ source }}/*/{{ basin_id }}_*.txt'
       csv_kwargs:
         sep: '\s+'
         header: 3
@@ -50,7 +50,7 @@ sources:
         default: "05056000"
     driver: csv
     args:
-      urlpath: 'gs://pangeo-data/camels/basin_dataset_public_v1p2/usgs_streamflow/*/{{ basin_id }}_streamflow_qc.txt'
+      urlpath: 'gs://pangeo-ncar-camels/basin_dataset_public_v1p2/usgs_streamflow/*/{{ basin_id }}_streamflow_qc.txt'
       csv_kwargs:
         sep: '\s+'
         names: ['basin', 'Year', 'Mnth', 'Day', 'QObs', 'flag']


### PR DESCRIPTION
These changes reflect the copying of NCAR Camels / SoilGrids to their own requester pays buckets, `gs://pangeo-ncar-camels` and `gs://pangeo-ncar-soilgrids`. 

Once this PR is merged and verified, we can begin removing the copies of the data in `gs://pangeo-data`.