### PR TITLE
Add requester_pays options to Camels and SoilGrids

### DIFF
--- a/intake-catalogs/hydro.yaml
+++ b/intake-catalogs/hydro.yaml
@@ -81,6 +81,8 @@ sources:
     args:
       urlpath: "gs://pangeo-ncar-soilgrids/{{ variable }}_250m.tif"
       chunks: {'y': 5120, 'x': 5120}
+      storage_options:
+        requester_pays: True
 
   soil_grids_multi_level:
     description: Global gridded soil information in COG format
@@ -100,6 +102,8 @@ sources:
     args:
       urlpath: "gs://pangeo-ncar-soilgrids/{{ variable }}_sl{{ '%01d' % level }}_250m.tif"
       chunks: {'y': 5120, 'x': 5120}
+      storage_options:
+        requester_pays: True
 
   camels:
     args:

--- a/intake-catalogs/hydro/camels.yaml
+++ b/intake-catalogs/hydro/camels.yaml
@@ -17,6 +17,8 @@ sources:
         sep: '\s+'
         header: 3
         parse_dates: {'date': ['Year', 'Mnth', 'Day', 'Hr']}
+      storage_options:
+        requester_pays: True
     metadata:
       origin_url: 'https://ral.ucar.edu/solutions/products/camels'
       
@@ -56,6 +58,8 @@ sources:
         names: ['basin', 'Year', 'Mnth', 'Day', 'QObs', 'flag']
         parse_dates: {'date': ['Year', 'Mnth', 'Day']}
         na_values: -999.0
+      storage_options:
+        requester_pays: True
     metadata:
       origin_url: 'https://ral.ucar.edu/solutions/products/camels'
 


### PR DESCRIPTION
Addresses the move of these datasets to requester pays buckets in #98.