### PR TITLE
Add entries to channel.yaml

### DIFF
--- a/intake-catalogs/ocean/channel.yaml
+++ b/intake-catalogs/ocean/channel.yaml
@@ -37,3 +37,71 @@ sources:
       consolidated: True
       storage_options:
         requester_pays: True
+        
+  MITgcm_channel_ridge_01km_tracer_snap10D:
+    description: >
+      MITgcm channel ridge simulations at 1km resolution
+      tracer snapshots every 10 days
+    metadata:
+      uploader_github: charlesbluca
+      uploader_email: charles@ldeo.columbia.edu
+      tags:
+        - ocean
+        - model
+    driver: zarr
+    args:
+      urlpath: gs://pangeo-ldeo-mitgcm/channel_ridge_resolutions/01km/tracer_10day_snap
+      consolidated: True
+      storage_options:
+        requester_pays: True
+              
+  MITgcm_channel_ridge_05km_tracer_snap10D:
+    description: >
+      MITgcm channel ridge simulations at 5km resolution
+      tracer snapshots every 10 days
+    metadata:
+      uploader_github: charlesbluca
+      uploader_email: charles@ldeo.columbia.edu
+      tags:
+        - ocean
+        - model
+    driver: zarr
+    args:
+      urlpath: gs://pangeo-ldeo-mitgcm/channel_ridge_resolutions/05km/tracer_10day_snap
+      consolidated: True
+      storage_options:
+        requester_pays: True
+        
+  MITgcm_channel_ridge_20km_tracer_snap10D:
+    description: >
+      MITgcm channel ridge simulations at 20km resolution
+      tracer snapshots every 10 days
+    metadata:
+      uploader_github: charlesbluca
+      uploader_email: charles@ldeo.columbia.edu
+      tags:
+        - ocean
+        - model
+    driver: zarr
+    args:
+      urlpath: gs://pangeo-ldeo-mitgcm/channel_ridge_resolutions/20km/tracer_10day_snap
+      consolidated: True
+      storage_options:
+        requester_pays: True
+        
+  MITgcm_channel_run_tracers_restored:
+    description: >
+      MITgcm channel run tracers restored
+    metadata:
+      uploader_github: charlesbluca
+      uploader_email: charles@ldeo.columbia.edu
+      tags:
+        - ocean
+        - model
+    driver: zarr
+    args:
+      urlpath: gs://pangeo-ldeo-mitgcm/run_tracers_restored_zarr
+      consolidated: True
+      storage_options:
+        requester_pays: True
+        

--- a/intake-catalogs/ocean/channel.yaml
+++ b/intake-catalogs/ocean/channel.yaml
@@ -38,11 +38,13 @@ sources:
       storage_options:
         requester_pays: True
         
-  MITgcm_channel_ridge_01km_tracer_snap10D:
+  channel_ridge_resolutions_01km:
     description: >
-      MITgcm channel ridge simulations at 1km resolution
-      tracer snapshots every 10 days
+      MITgcm output from a wind and thermally driven channel with a ridge at 1km resolution, and surface forced tracer
     metadata:
+      publication: Submesoscale Vertical Velocities Enhance Tracer Subduction in an Idealized Antarctic Circumpolar Current, Balwada et al 2018 (GRL)
+      time_resolution: 10 day snapshots
+      duration: 1 year 
       uploader_github: charlesbluca
       uploader_email: charles@ldeo.columbia.edu
       tags:
@@ -55,11 +57,13 @@ sources:
       storage_options:
         requester_pays: True
               
-  MITgcm_channel_ridge_05km_tracer_snap10D:
+  channel_ridge_resolutions_05km:
     description: >
-      MITgcm channel ridge simulations at 5km resolution
-      tracer snapshots every 10 days
+      MITgcm output from a wind and thermally driven channel with a ridge at 5km resolution, and surface forced tracer
     metadata:
+      publication: Submesoscale Vertical Velocities Enhance Tracer Subduction in an Idealized Antarctic Circumpolar Current, Balwada et al 2018 (GRL)
+      time_resolution: 10 day snapshots
+      duration: 1 year 
       uploader_github: charlesbluca
       uploader_email: charles@ldeo.columbia.edu
       tags:
@@ -72,11 +76,13 @@ sources:
       storage_options:
         requester_pays: True
         
-  MITgcm_channel_ridge_20km_tracer_snap10D:
+  channel_ridge_resolutions_20km:
     description: >
-      MITgcm channel ridge simulations at 20km resolution
-      tracer snapshots every 10 days
+      MITgcm output from a wind and thermally driven channel with a ridge at 20km resolution, and surface forced tracer
     metadata:
+      publication: Submesoscale Vertical Velocities Enhance Tracer Subduction in an Idealized Antarctic Circumpolar Current, Balwada et al 2018 (GRL)
+      time_resolution: 10 day snapshots
+      duration: 1 year 
       uploader_github: charlesbluca
       uploader_email: charles@ldeo.columbia.edu
       tags:
@@ -89,10 +95,12 @@ sources:
       storage_options:
         requester_pays: True
         
-  MITgcm_channel_run_tracers_restored:
+  run_tracers_restored_zarr:
     description: >
-      MITgcm channel run tracers restored
+      MITgcm output from a wind and thermally driven channel with a ridge at 5km resolution and interior restored tracers
     metadata:
+      time_resolution: 3 day snapshots
+      duration: 16.5 years
       uploader_github: charlesbluca
       uploader_email: charles@ldeo.columbia.edu
       tags:


### PR DESCRIPTION
These additions to the channel catalog reflect the location of some data from `gs://pangeo-data` to `gs://pangeo-ldeo-mitgcm`, as outlined in #103. I don't have much knowledge of channel so would appreciate a review of the entry names and their descriptions!