### PR TITLE
add remote url datasets to master catalog

### DIFF
--- a/intake-catalogs/atmosphere.yaml
+++ b/intake-catalogs/atmosphere.yaml
@@ -36,7 +36,7 @@ sources:
       urlpath: gs://pangeo-vulcan-sam/3d
       storage_options:
         requester_pays: True
-       
+
   sam_ngaqua_qobs_eqx_2d:
     description: 2D fields from a near-global Aquaplanet Simulation with the System for Atmospheric Modeling
     metadata:
@@ -86,3 +86,34 @@ sources:
       consolidated: True
       storage_options:
         requester_pays: True
+
+  HadCRUT4:
+    description: HadCRUT temperature anomalies wrt. 1960-1989
+    metadata:
+      url: https://crudata.uea.ac.uk/cru/data/temperature/
+      doi: 10.1029/2011JD017187
+      tags:
+        - atmosphere
+        - land
+        - ocean
+        - observations
+        - temperature
+        - anomaly
+      plots:
+        temperature_anomaly_over_time:
+          title: HadCRUT4 temperature anomly wrt. 1960-1989
+          kind: contourf
+          x: longitude
+          y: latitude
+          z: temperature_anomaly
+          groupby: time
+          cmap: RdBu_r
+          levels: 20
+          # clim: (-10, 10)  # once https://github.com/holoviz/hvplot/pull/492 is merged
+    driver: netcdf
+    args:
+      urlpath: simplecache::https://crudata.uea.ac.uk/cru/data/temperature/HadCRUT.4.6.0.0.median.nc
+      chunks: {'time': 'auto'}
+      xarray_kwargs:
+        use_cftime: True  # needed for plot.temperature_anomaly_over_time
+        drop_variables: field_status

--- a/intake-catalogs/ocean.yaml
+++ b/intake-catalogs/ocean.yaml
@@ -17,7 +17,7 @@ sources:
       consolidated: True
       storage_options:
         requester_pays: True
-      
+
   cesm_mom6_example:
     description: CESM MOM6 Ocean Model Example Data
     metadata:
@@ -30,7 +30,7 @@ sources:
     driver: zarr
     args:
       urlpath: gs://pangeo-cesm-mom6
-      consolidated: True   
+      consolidated: True
       storage_options:
         requester_pays: True
 
@@ -77,7 +77,7 @@ sources:
       consolidated: True
       storage_options:
         requester_pays: True
-      
+
   ECCO_layers:
     description: Rerun of Estimating the Circulation and Climate of the Ocean (ECCO) with the layers package
     metadata:
@@ -127,10 +127,97 @@ sources:
     description: 'MITgcm High Resolution Channel Simulations'
     driver: intake.catalog.local.YAMLFileCatalog
     metadata: {}
-    
+
   MEOM_NEMO:
     args:
       path: "{{CATALOG_DIR}}/ocean/MEOM-NEMO.yaml"
     description: 'NEMO North Atlantic Ocean Model simulations produced at MEOM'
+    driver: intake.catalog.local.YAMLFileCatalog
+    metadata: {}
+
+  GISTEMP:
+    description: GISS Surface Temperature Analysis (GISTEMP v4)
+    metadata:
+      url: https://data.giss.nasa.gov/gistemp/
+      doi: 10.1029/2018JD029522
+      tags:
+        - ocean
+        - observations
+        - temperature
+    driver: netcdf
+    args:
+      urlpath: simplecache::https://data.giss.nasa.gov/pub/gistemp/gistemp1200_GHCNv4_ERSSTv5.nc.gz
+      storage_options:
+        simplecache:
+          # compression: gzip
+          same_names: True  # caches gz file as gz file
+      chunks: {'time':'auto'}
+
+  HadISST1:
+    description: Hadley Centre Sea Ice and Sea Surface Temperature data set 1
+    metadata:
+      url: https://www.metoffice.gov.uk/hadobs/hadisst/
+      doi: 10.1029/2002JD002670
+      tags:
+        - ocean
+        - observations
+        - temperature
+        - seaice
+      plots:
+        sst_over_time:
+          title: HadISST1 temperature anomly wrt. 1960-1989
+          kind: contourf
+          z: sst
+          groupby: time
+          cmap: RdBu_r
+          levels: 20
+          # clim: (-10, 10)  # once https://github.com/holoviz/hvplot/pull/492 is merged
+    driver: netcdf
+    args:
+      urlpath: simplecache::https://www.metoffice.gov.uk/hadobs/hadisst/data/HadISST_sst.nc.gz
+      chunks: {'time': -1}
+      storage_options:
+        simplecache:
+          # compression: gzip
+          same_names: True
+      xarray_kwargs:
+        use_cftime: True
+        drop_variables: time_bnds
+
+  HadSST4:
+    description: Met Office Hadley Centre's sea surface temperature data set 4
+    metadata:
+      url: https://www.metoffice.gov.uk/hadobs/hadsst4/
+      doi: 10.1029/2018JD029867
+      tags:
+        - ocean
+        - observations
+        - temperature
+      plots:
+        temperature_anomaly_over_time:
+          title: HadSST4 temperature anomly wrt. 1960-1989
+          kind: contourf
+          z: tos
+          groupby: time
+          cmap: RdBu_r
+          levels: 20
+          # clim: (-10, 10)  # once https://github.com/holoviz/hvplot/pull/492 is merged
+    driver: netcdf
+    parameters:
+      file:
+        description: name of file
+        type: str
+        default: median
+        allowed: [median, total_incertainty, measurement_and_sampling_uncertainty, uncorrelated_measurement_uncertainty, correlated_measurement_uncertainty, number_of_observations, number_of_superobservations, unadjusted, actuals_median, actuals_ensemble]
+    args:
+      urlpath: simplecache::https://www.metoffice.gov.uk/hadobs/hadsst4/data/netcdf/HadSST.4.0.0.0_{{file}}.nc
+      chunks: {'time': -1}
+      xarray_kwargs:
+        use_cftime: True
+
+  biogeochemistry:
+    args:
+      path: "{{CATALOG_DIR}}/ocean/marine_biogeochemistry.yaml"
+    description: 'marine biogeochemical datasets'
     driver: intake.catalog.local.YAMLFileCatalog
     metadata: {}

--- a/intake-catalogs/ocean/marine_biogeochemistry.yaml
+++ b/intake-catalogs/ocean/marine_biogeochemistry.yaml
@@ -1,0 +1,88 @@
+plugins:
+  source:
+  - module: intake_xarray
+
+sources:
+  CSIR-ML6:
+    description: Global surface ocean pCO2 from CSIR-ML6
+    metadata:
+      url: https://figshare.com/articles/Global_surface_ocean_pCO2_from_CSIR-ML6_2020a_/12652100/4
+      doi:
+        - 10.5194/gmd-12-5113-2019
+        - 10.6084/m9.figshare.12652100.v4
+      tags:
+        - ocean
+        - observations
+        - spco2
+        - fgco2
+      plots:
+        spco2_over_ensemble_member_and_time:
+          title: CSIR-ML6 spco2 over ensemble and time
+          kind: contourf
+          x: lon
+          y: lat
+          z: spco2_ensemble
+          groupby: ['time','member']
+          cmap: viridis
+          levels: 20
+          # clim: (-10, 10)  # once https://github.com/holoviz/hvplot/pull/492 is merged
+    driver: netcdf
+    args:
+      urlpath: simplecache::https://ndownloader.figshare.com/files/23875943
+      chunks: {'time':'auto'}
+      xarray_kwargs:
+        use_cftime: True
+      storage_options:
+        simplecache:
+          cache_storage: CSIR-ML6
+          same_names: True
+
+  SOM_FFN:
+    description: Global surface ocean pCO2 from SOM_FFN
+    driver: netcdf
+    parameters:
+      version:
+        description: version released in year
+        type: int
+        default: 2020
+        allowed: [2020]  # paths for 2017 and 2018 are formatted slightly different
+    metadata:
+      url: https://www.nodc.noaa.gov/ocads/oceans/SPCO2_1982_present_ETH_SOM_FFN.html
+      doi:
+        - 10.1002/2015GB005359
+        - 10.7289/V5Z899N6
+      tags:
+        - ocean
+        - observations
+        - spco2
+        - fgco2
+      plots:
+        fgco2_over_time:
+          title: SOM-FFN fgco2 over time
+          kind: contourf
+          x: lon
+          y: lat
+          z: fgco2_smoothed
+          groupby: time
+          cmap: RdBu_r
+          levels: 20
+          # clim: (-10, 10)  # once https://github.com/holoviz/hvplot/pull/492 is merged
+        fgco2_timeseries_location:
+          title: fgco2 timeseries at (lon,lat) location
+          kind: line
+          x: time
+          y: fgco2_smoothed
+          groupby: ['lon','lat']
+        fgco2_timeseries_latitude:
+          title: fgco2 timeseries at latitude
+          kind: contourf
+          y: time
+          x: lon
+          z: fgco2_smoothed
+          groupby: lat
+          levels: 20
+    args:
+      urlpath: simplecache::https://data.nodc.noaa.gov/ncei/ocads/data/0160558/MPI_SOM-FFN_v{{version}}/spco2_MPI-SOM_FFN_v{{version}}.nc
+      chunks: {'time':'120'}
+      xarray_kwargs:
+        drop_variables: date


### PR DESCRIPTION
- adds atm: HadCRUT4
- ocean: HadISST1, GISTEMP, HadSST4
- marine biogeochemistry: SOM_FFN, CSIR-ML6

Closes: #113 

open questions:
- how much predefined plots? I would say optimal but recommended
- how to test? 
- add data source type tag in metadata? @jhamman which could be used to test dataset availability with `xr.open_dataset(url.strip('simplecache::'), chunks={})` without downloading, now with caching `to_dask()` is not lazy anymore
- should caching options be required? my opinion not, but really nice to have, but laziness of `to_dask` breaks
- how many options to set in catalog? I set `use_cftime=True` to make `hvplot` work but `hvplot` seems to be buggy with the new `matplotlib` version
- which `tags` to set?