### PR TITLE
Use consolidated metadata for all Zarr datasets

### DIFF
--- a/intake-catalogs/atmosphere.yaml
+++ b/intake-catalogs/atmosphere.yaml
@@ -22,6 +22,7 @@ sources:
     driver: zarr
     args:
       urlpath: gs://pangeo-nasa-trmm
+      consolidated: True
       storage_options:
         requester_pays: True
 
@@ -34,6 +35,7 @@ sources:
     driver: zarr
     args:
       urlpath: gs://pangeo-vulcan-sam/3d
+      consolidated: True
       storage_options:
         requester_pays: True
        
@@ -46,6 +48,7 @@ sources:
     driver: zarr
     args:
       urlpath: gs://pangeo-vulcan-sam/2d
+      consolidated: True
       storage_options:
         requester_pays: True
 
@@ -60,6 +63,7 @@ sources:
     driver: zarr
     args:
       urlpath: gs://pangeo-noaa-esrl-gpcp
+      consolidated: True
       storage_options:
         requester_pays: True
 

--- a/intake-catalogs/hydro.yaml
+++ b/intake-catalogs/hydro.yaml
@@ -13,6 +13,7 @@ sources:
     driver: zarr
     args:
       urlpath: gs://pangeo-cgiar-pet
+      consolidated: True
       storage_options:
         requester_pays: True
 


### PR DESCRIPTION
This PR sets `consolidated: True` for Zarr datasets in our Intake catalogs, so that they can potentially be accessed by STAC Browser down the line.

Before this is merged, I would like to also consolidate the metadata for `hydro.nldas_hru_forcing` and `hydro.usgs_streamflow_observations`, which reside in S3 storage.