### PR TITLE
Add data collections in S3 to climate catalog

### DIFF
--- a/intake-catalogs/climate.yaml
+++ b/intake-catalogs/climate.yaml
@@ -25,3 +25,10 @@ sources:
     description: "TRACMIP in Pangeo Google Cloud Storage"
     driver: intake_esm.esm_datastore
     metadata: {}
+    
+  tracmip_s3:
+    args:
+      esmcol_obj: "https://cmip6-pds.s3-us-west-2.amazonaws.com/tracmip.json"
+    description: "TRACMIP in Pangeo Google Cloud Storage"
+    driver: intake_esm.esm_datastore
+    metadata: {}

--- a/intake-catalogs/climate.yaml
+++ b/intake-catalogs/climate.yaml
@@ -11,10 +11,24 @@ sources:
     description: 'CMIP6 in Google Cloud Storage'
     driver: intake_esm.esm_datastore
     metadata: {}
+    
+  cmip6_s3:
+    args:
+      esmcol_obj: "https://cmip6-pds.s3-us-west-2.amazonaws.com/pangeo-cmip6.json"
+    description: 'CMIP6 in Google Cloud Storage'
+    driver: intake_esm.esm_datastore
+    metadata: {}
    
   GFDL_CM2_6:
     args:
       esmcol_obj: "https://storage.googleapis.com/cmip6/gfdl_cm2_6.json"
+    description: "NOAA-GFDL CM2.6 in Google Cloud Storage"
+    driver: intake_esm.esm_datastore
+    metadata: {}
+    
+  GFDL_CM2_6_s3:
+    args:
+      esmcol_obj: "https://cmip6-pds.s3-us-west-2.amazonaws.com/gfdl_cm2_6.json"
     description: "NOAA-GFDL CM2.6 in Google Cloud Storage"
     driver: intake_esm.esm_datastore
     metadata: {}

--- a/intake-catalogs/climate.yaml
+++ b/intake-catalogs/climate.yaml
@@ -15,7 +15,7 @@ sources:
   cmip6_s3:
     args:
       esmcol_obj: "https://cmip6-pds.s3-us-west-2.amazonaws.com/pangeo-cmip6.json"
-    description: 'CMIP6 in Google Cloud Storage'
+    description: 'CMIP6 in S3 Storage'
     driver: intake_esm.esm_datastore
     metadata: {}
    
@@ -29,7 +29,7 @@ sources:
   GFDL_CM2_6_s3:
     args:
       esmcol_obj: "https://cmip6-pds.s3-us-west-2.amazonaws.com/gfdl_cm2_6.json"
-    description: "NOAA-GFDL CM2.6 in Google Cloud Storage"
+    description: "NOAA-GFDL CM2.6 in S3 Storage"
     driver: intake_esm.esm_datastore
     metadata: {}
     
@@ -43,6 +43,6 @@ sources:
   tracmip_s3:
     args:
       esmcol_obj: "https://cmip6-pds.s3-us-west-2.amazonaws.com/tracmip.json"
-    description: "TRACMIP in Pangeo Google Cloud Storage"
+    description: "TRACMIP in Pangeo S3 Storage"
     driver: intake_esm.esm_datastore
     metadata: {}


### PR DESCRIPTION
This adds the S3 mirrors of our GS data collections to the climate catalog.

I didn't change the names of any of the original entries so we can take some time to smoothly transition any resources that may have relied on the original URLs, but it might be good in the future to append `_gs` to those entries to make it clear who is hosting them.